### PR TITLE
Dynamic artifacts compiled at runtime

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@
 apply plugin: 'java'
 apply plugin: 'eclipse'
 
-version '2.4-SNAPSHOT'
+version '2.4-DYN-SNAPSHOT'
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
@@ -40,6 +40,8 @@ sourceSets {
 dependencies {
   compile files('libs/lipermi-0.4.jar')
   compile group: 'org.jason-lang', name: 'jason'    , version: '2.4-SNAPSHOT'  , changing: true , transitive: false
+  // https://mvnrepository.com/artifact/net.openhft/compiler
+  compile group: 'net.openhft', name: 'compiler', version: '2.3.1'
 }
 
 /* still not used */

--- a/src/main/java/cartago/DefaultArtifactFactory.java
+++ b/src/main/java/cartago/DefaultArtifactFactory.java
@@ -1,5 +1,10 @@
 package cartago;
 
+import java.io.File;
+import java.io.FileInputStream;
+
+import net.openhft.compiler.CachedCompiler;
+
 public class DefaultArtifactFactory extends ArtifactFactory {
 	
 	public DefaultArtifactFactory(){
@@ -8,10 +13,29 @@ public class DefaultArtifactFactory extends ArtifactFactory {
 	
 	public Artifact createArtifact(String templateName) throws CartagoException {
 		try {
-			Class cl = Class.forName(templateName);
-			return (Artifact)cl.newInstance();
-		} catch(Exception ex){
-			throw new CartagoException("Template not found: "+templateName);
+			Class cl;
+			if (templateName.substring(0, 8).equals("cartago.")) {
+				cl = Class.forName(templateName);
+			} else {
+				String filename = "src/env/" + templateName.replace(".", "/") + ".java";
+
+				File file = new File(filename);
+				FileInputStream fis = new FileInputStream(file);
+				byte[] data = new byte[(int) file.length()];
+				fis.read(data);
+				fis.close();
+
+				String javacode = new String(data, "UTF-8");
+
+				ClassLoader cloader = new ClassLoader() {
+				};
+				CachedCompiler cc = new CachedCompiler(null, null);
+
+				cl = cc.loadFromJava(cloader, templateName, javacode);
+			}
+			return (Artifact) cl.newInstance();
+		} catch (Exception ex) {
+			throw new CartagoException("Template not found: " + templateName);
 		}
 	}
 }

--- a/src/main/java/cartago/DefaultArtifactFactory.java
+++ b/src/main/java/cartago/DefaultArtifactFactory.java
@@ -14,9 +14,7 @@ public class DefaultArtifactFactory extends ArtifactFactory {
 	public Artifact createArtifact(String templateName) throws CartagoException {
 		try {
 			Class cl;
-			if (templateName.substring(0, 8).equals("cartago.")) {
-				cl = Class.forName(templateName);
-			} else {
+			if (templateName.substring(0, 8).equals("dynamic.")) {
 				String filename = "src/env/" + templateName.replace(".", "/") + ".java";
 
 				File file = new File(filename);
@@ -32,6 +30,8 @@ public class DefaultArtifactFactory extends ArtifactFactory {
 				CachedCompiler cc = new CachedCompiler(null, null);
 
 				cl = cc.loadFromJava(cloader, templateName, javacode);
+			} else {
+				cl = Class.forName(templateName);
 			}
 			return (Artifact) cl.newInstance();
 		} catch (Exception ex) {


### PR DESCRIPTION
Allowing environment dimension be open for new artifact designs. We are proposing to use the library "net.openhft" to compile artifact ".java" files and load them at createArtifact on DefaultArtifactFactory.

It is working properly in a few tests I done. Is also available in the JaCaMo-Rest application in http://191.36.8.42:8080. There it is possible to change artifact codes and ask to "one" agent to dispose and ask to agent owner to build the artifact again (with new code).

There are some notes to take care:
- This version is assuming that the .java files are stored on "src/env/ " folder, default folder for JaCaMo. Other CArtAgO application may face problems with it.
- I did not track properly all the life cicle of the artifact, specially on creation to ensure that the compiler and loading process are fault tolerants. Although this new process brings new variables, the earlier process may also face same issue.