### PR TITLE
support for multiple AbstractWSPRuleEngine in a single workspace

### DIFF
--- a/src/main/java/cartago/WorkspaceArtifact.java
+++ b/src/main/java/cartago/WorkspaceArtifact.java
@@ -436,6 +436,15 @@ public class WorkspaceArtifact extends Artifact {
 			failed(ex.getMessage());
 		}
 	}
+	
+	@OPERATION void addWSPRuleEngine(AbstractWSPRuleEngine man){
+		try {
+			man.setKernel(wsp);
+			wsp.addWSPRuleEngine(man);
+		} catch(Exception ex){
+			failed(ex.getMessage());
+		}
+	}
 
 	/* Topology management */
 	


### PR DESCRIPTION
Adding support for multiple AbstractWSPRuleEngine in a workspace.
This change enables multiple external entities (e.g. institutions, normative engines, etc.) to handle events of the same workspace.