### PR TITLE
add Method to remove Workspaces

### DIFF
--- a/src/main/java/cartago/Workspace.java
+++ b/src/main/java/cartago/Workspace.java
@@ -1952,7 +1952,7 @@ public class Workspace {
 					env.serveOperation(item);
 					//nfailures = 0;
 				} catch (Exception ex){
-					if (ex instanceof InterruptedException){
+					if (ex instanceof InterruptedException && isStopped()){
 						break;
 					} else {
 					ex.printStackTrace();

--- a/src/main/java/cartago/Workspace.java
+++ b/src/main/java/cartago/Workspace.java
@@ -1952,13 +1952,12 @@ public class Workspace {
 					env.serveOperation(item);
 					//nfailures = 0;
 				} catch (Exception ex){
+					if (ex instanceof InterruptedException){
+						break;
+					} else {
 					ex.printStackTrace();
 					env.log("[ENV-CONTROLLER] uncaught operation exception: "+ex);
-					/*
-					 nfailures++;
-					if (nfailures>10){
-						break;
-					}*/
+					}
 				}
 			}
 

--- a/src/main/java/cartago/Workspace.java
+++ b/src/main/java/cartago/Workspace.java
@@ -194,6 +194,16 @@ public class Workspace {
 	}
 
 	/**
+	 * Remove a child workspace
+	 *
+	 * @param name workspace name
+	 * @return
+	 */
+	public synchronized Optional<WorkspaceDescriptor> removeWorkspace(String name) {
+		return this.removeWorkspace(name, (ICartagoLogger) null);
+	}
+
+	/**
 	 * Create a child workspace on a remote node
 	 * 
 	 * @param name
@@ -236,6 +246,26 @@ public class Workspace {
 			} else {
 				throw new CartagoException("workspace already present");
 			}
+	}
+
+	/**
+	 * Remove a child workspace
+	 *
+	 * @param name
+	 * @param log
+	 * @return
+	 */
+	public synchronized Optional<WorkspaceDescriptor> removeWorkspace(String name, ICartagoLogger log) {
+		Optional<WorkspaceDescriptor> res = this.resolveWSP(name);
+		if(res.isPresent()) {
+			WorkspaceDescriptor des = res.get();
+			des.getWorkspace().shutdown();
+			this.childWsp.remove(name);
+			return Optional.of(des);
+		} else {
+			return Optional.empty();
+
+		}
 	}
 	
 	/**


### PR DESCRIPTION
There was currently no way to remove workspaces so I added a method.

Method could also return void, but I prefer to be able to differentiate between actually removing something or doing nothing because the workspace is not there.

Additionally I noticed, that when a Workspace is shutdown through the .shutdown() method it will (catch) but log many exceptions like this:
```
java.lang.InterruptedException
        at java.base/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:1722)
        at java.base/java.util.concurrent.ArrayBlockingQueue.take(ArrayBlockingQueue.java:420)
        at cartago.Workspace$EnvironmentController.run(Workspace.java:1949)
[ENV] [ENV-CONTROLLER] uncaught operation exception: java.lang.InterruptedException
```
This is because the shutdown() method calls the stopActivity() method in the EnvironmentController of the workspace. Which interrupts the thread. and the run() method of the Environment Controller is set to log all exceptions. I just added a case for when it is an instance of InterruptedException and isStopped() return true it will not log anything, because it works as expected.

